### PR TITLE
Add possibility to pass your own ObjectMapper, and disable failing on unknown properties

### DIFF
--- a/src/main/java/com/lilittlecat/chatgpt/offical/ChatGPT.java
+++ b/src/main/java/com/lilittlecat/chatgpt/offical/ChatGPT.java
@@ -32,7 +32,7 @@ public class ChatGPT {
     private final String apiKey;
     private String apiHost = DEFAULT_CHAT_COMPLETION_API_URL;
     protected OkHttpClient client;
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private ObjectMapper objectMapper = DEFAULT_OBJECT_MAPPER;
 
     public ChatGPT(String apiKey) {
         this.apiKey = apiKey;
@@ -62,10 +62,11 @@ public class ChatGPT {
         this.client = new OkHttpClient();
     }
 
-    public ChatGPT(String apiHost, String apiKey, OkHttpClient client) {
+    public ChatGPT(String apiHost, String apiKey, OkHttpClient client, ObjectMapper objectMapper) {
         this.apiHost = apiHost;
         this.apiKey = apiKey;
         this.client = client;
+        this.objectMapper = objectMapper;
     }
 
     public ChatGPT(String apiHost, String apiKey, Proxy proxy) {

--- a/src/main/java/com/lilittlecat/chatgpt/offical/entity/Constant.java
+++ b/src/main/java/com/lilittlecat/chatgpt/offical/entity/Constant.java
@@ -1,5 +1,8 @@
 package com.lilittlecat.chatgpt.offical.entity;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 /**
  * <p>
  * Constants
@@ -21,4 +24,5 @@ public class Constant {
     public static final String DEFAULT_CHAT_COMPLETION_API_URL = "https://api.openai.com/v1/chat/completions";
     public static final String DEFAULT_USER = "user";
     public static final Model DEFAULT_MODEL = Model.GPT_3_5_TURBO;
+    public static final ObjectMapper DEFAULT_OBJECT_MAPPER = new ObjectMapper().disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
 }


### PR DESCRIPTION
Currently the library does not work, because of additional field introduced to ChatGPT API response. This PR adds a possibility to pass your own ObjectMapper with proper configuration to be able to prevent such problems in the future, and disables failing on unknown fields in default instance

Solves the issue mentioned in https://github.com/LiLittleCat/ChatGPT/issues/18 https://github.com/LiLittleCat/ChatGPT/issues/17